### PR TITLE
Use raw github reference

### DIFF
--- a/apl_reference_implementation_bundle/revision_3/schemas/sdos/x-oca-coa-playbook-ext.json
+++ b/apl_reference_implementation_bundle/revision_3/schemas/sdos/x-oca-coa-playbook-ext.json
@@ -6,7 +6,7 @@
     "type": "object",
     "allOf": [
         {
-            "$ref": "https://github.com/oasis-open/cti-stix2-json-schemas/blob/master/schemas/sdos/course-of-action.json"
+            "$ref": "https://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/sdos/course-of-action.json"
         },
         {
             "properties": {


### PR DESCRIPTION
For consistency with the other schemas, the raw github reference is used for x-oca-coa-playbook-ext.